### PR TITLE
Simplify `get_partition_info()` and prefer using partition name

### DIFF
--- a/builder/frameworks/esp8266-rtos-sdk.py
+++ b/builder/frameworks/esp8266-rtos-sdk.py
@@ -938,7 +938,7 @@ def get_partition_info(pt_path, pt_params):
         "offset",
     ]
 
-    if pt_params["name"]:
+    if "name" in pt_params:
         if pt_params["name"] == "*boot":
             cmd.append("--partition-boot-default")
         else:
@@ -1343,7 +1343,7 @@ env["BUILDERS"]["ElfToBin"].action = action
 
 ota_partition_params = get_partition_info(
     env.subst("$PARTITIONS_TABLE_CSV"),
-    {"name": "ota", "type": "data", "subtype": "ota"},
+    {"type": "data", "subtype": "ota"},
 )
 
 if ota_partition_params["size"] and ota_partition_params["offset"]:


### PR DESCRIPTION
Reading parttool code, it seems when `--partition-table-file` is provided, it doesn't use `--partition-table-offset`.

Also `--partition-name` is preferred over `--partition-type` and `--partition-subtype`.